### PR TITLE
Fix payload json serialization, bump version of package to 1.0.1.

### DIFF
--- a/PartnerSdk/pom.xml
+++ b/PartnerSdk/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.microsoft.store</groupId>
 	<artifactId>partnersdk</artifactId>
-	<version>1.0.0</version>
+	<version>1.0.1</version>
 	<packaging>jar</packaging>
 
 	<name>Partner Center Java SDK</name>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PartnerCenter Java SDK
+﻿# PartnerCenter Java SDK
 
 The Partner Center Java SDK, provides an SDK to interact with the Microsoft's Partner Center Service. This enables the Partners to perform the Partner Center operations programmatically or through their own portals. The Java SDK is the latest addition to existing portfolio of REST APIs and the C# SDK. This is currently tested and supports Java versions of Java 7 and above. 
 


### PR DESCRIPTION
This is a fix for the payload deserialization of the SDK, which currently always assumes there is a byte order mark on the beginning of our payloads.  This is an incorrect, and dangerous, assumption and must be corrected.

I can include more details about this if required.

Full disclosure, this is my personal GitHub, but I am a Microsoft employee making this commit.