### PR TITLE
Implement agreement API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,9 @@ local.properties
 .cache-main
 .scala_dependencies
 .worksheet
+
+# IntelliJ IDEA
+.idea
+*.iml
+PartnerSdk/target
+Samples/target

--- a/PartnerSdk/src/main/java/com/microsoft/store/partnercenter/IPartner.java
+++ b/PartnerSdk/src/main/java/com/microsoft/store/partnercenter/IPartner.java
@@ -6,6 +6,7 @@
 
 package com.microsoft.store.partnercenter;
 
+import com.microsoft.store.partnercenter.agreements.IAgreementMetaDataCollection;
 import com.microsoft.store.partnercenter.analytics.IPartnerAnalyticsCollection;
 import com.microsoft.store.partnercenter.auditrecords.IAuditRecordsCollection;
 import com.microsoft.store.partnercenter.countryvalidationrules.ICountryValidationRulesCollection;
@@ -133,4 +134,9 @@ public interface IPartner
      * Gets the validation operations available to the partner.
      */    
     IValidationOperations getValidations();
+
+    /***
+     * Gets the agreement metadata operations.
+     */
+    IAgreementMetaDataCollection getAgreements();
 }

--- a/PartnerSdk/src/main/java/com/microsoft/store/partnercenter/PartnerOperations.java
+++ b/PartnerSdk/src/main/java/com/microsoft/store/partnercenter/PartnerOperations.java
@@ -6,6 +6,8 @@
 
 package com.microsoft.store.partnercenter;
 
+import com.microsoft.store.partnercenter.agreements.AgreementMetaDataCollectionOperations;
+import com.microsoft.store.partnercenter.agreements.IAgreementMetaDataCollection;
 import com.microsoft.store.partnercenter.analytics.IPartnerAnalyticsCollection;
 import com.microsoft.store.partnercenter.analytics.PartnerAnalyticsCollectionOperations;
 import com.microsoft.store.partnercenter.auditrecords.AuditRecordsCollection;
@@ -140,7 +142,12 @@ public class PartnerOperations
 	 * The validation operations available to the partner.
 	 */
 	private IValidationOperations validations;
-	
+
+	/***
+	 * The agreement metadata collection operations.
+	 */
+	private IAgreementMetaDataCollection agreements;
+
 	/**
 	 * Initializes a new instance of the {@link #PartnerOperations} class.
 	 * 
@@ -407,5 +414,19 @@ public class PartnerOperations
 		}
 
 		return this.validations;
+	}
+
+	/***
+	 * Gets the agreement metadata operations.
+	 */
+	@Override
+	public IAgreementMetaDataCollection getAgreements()
+	{
+		if ( this.agreements == null )
+		{
+			this.agreements = new AgreementMetaDataCollectionOperations( this );
+		}
+
+		return this.agreements;
 	}
 }

--- a/PartnerSdk/src/main/java/com/microsoft/store/partnercenter/agreements/AgreementCollectionOperations.java
+++ b/PartnerSdk/src/main/java/com/microsoft/store/partnercenter/agreements/AgreementCollectionOperations.java
@@ -1,0 +1,73 @@
+// -----------------------------------------------------------------------
+// <copyright file="AgreementCollectionOperations.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation.  All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.agreements;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.microsoft.store.partnercenter.BasePartnerComponentString;
+import com.microsoft.store.partnercenter.IPartner;
+import com.microsoft.store.partnercenter.PartnerService;
+import com.microsoft.store.partnercenter.models.ResourceCollection;
+import com.microsoft.store.partnercenter.models.agreements.Agreement;
+import com.microsoft.store.partnercenter.network.PartnerServiceProxy;
+import com.microsoft.store.partnercenter.utils.StringHelper;
+
+import java.text.MessageFormat;
+import java.util.Locale;
+
+public class AgreementCollectionOperations
+        extends BasePartnerComponentString
+        implements IAgreementCollection
+{
+    /**
+     * Initializes a new instance of the {@link #AgreementCollectionOperations} class.
+     *
+     * @param rootPartnerOperations The root partner operations instance.
+     */
+    public AgreementCollectionOperations( IPartner rootPartnerOperations, String customerId )
+    {
+        super( rootPartnerOperations, customerId );
+        if ( StringHelper.isNullOrWhiteSpace(customerId) )
+        {
+            throw new IllegalArgumentException( "customerId must be set" );
+        }
+    }
+
+    /***
+     * Adds accepted agreement.
+     *
+     * @param newEntity Agreement to add.
+     *
+     * @return Agreement entity.
+     */
+    @Override
+    public Agreement create( Agreement newEntity )
+    {
+        if ( newEntity == null )
+        {
+            throw new IllegalArgumentException( "entity can't be null." );
+        }
+
+        return new PartnerServiceProxy<Agreement, Agreement>(new TypeReference<Agreement>() {}, this.getPartner(),
+                MessageFormat.format( PartnerService.getInstance().getConfiguration().getApis()
+                        .get( "AddAgreement" ).getPath(), this.getContext(), Locale.US ) ).post( newEntity );
+    }
+
+    /***
+     * Retrieves all agreements.
+     *
+     * @return The agreements.
+     */
+    @Override
+    public ResourceCollection<Agreement> get()
+    {
+        return new PartnerServiceProxy<Agreement, ResourceCollection<Agreement>>(
+                new TypeReference<ResourceCollection<Agreement>>() {}, this.getPartner(),
+                MessageFormat.format( PartnerService.getInstance().getConfiguration().getApis()
+                                .get( "GetAgreements" ).getPath(),
+                        this.getContext(), Locale.US ) ).get();
+    }
+}

--- a/PartnerSdk/src/main/java/com/microsoft/store/partnercenter/agreements/AgreementMetaDataCollectionOperations.java
+++ b/PartnerSdk/src/main/java/com/microsoft/store/partnercenter/agreements/AgreementMetaDataCollectionOperations.java
@@ -1,0 +1,48 @@
+// -----------------------------------------------------------------------
+// <copyright file="AgreementMetaDataCollectionOperations.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation.  All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.agreements;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.microsoft.store.partnercenter.BasePartnerComponentString;
+import com.microsoft.store.partnercenter.IPartner;
+import com.microsoft.store.partnercenter.PartnerService;
+import com.microsoft.store.partnercenter.models.ResourceCollection;
+import com.microsoft.store.partnercenter.models.agreements.AgreementMetaData;
+import com.microsoft.store.partnercenter.network.PartnerServiceProxy;
+
+import java.text.MessageFormat;
+import java.util.Locale;
+
+public class AgreementMetaDataCollectionOperations
+        extends BasePartnerComponentString
+        implements IAgreementMetaDataCollection
+{
+    /**
+     * Initializes a new instance of the {@link #AgreementMetaDataCollectionOperations} class.
+     *
+     * @param rootPartnerOperations The root partner operations instance.
+     */
+    public AgreementMetaDataCollectionOperations( IPartner rootPartnerOperations )
+    {
+        super( rootPartnerOperations );
+    }
+
+    /**
+     * Retrieves all current agreement metadata.
+     *
+     * @return The current agreement metadata.
+     */
+    @Override
+    public ResourceCollection<AgreementMetaData> get()
+    {
+        return new PartnerServiceProxy<AgreementMetaData, ResourceCollection<AgreementMetaData>>(
+                new TypeReference<ResourceCollection<AgreementMetaData>>() {}, this.getPartner(),
+                MessageFormat.format( PartnerService.getInstance().getConfiguration().getApis()
+                                .get( "GetAllAgreements" ).getPath(),
+                        this.getContext(), Locale.US ) ).get();
+    }
+}

--- a/PartnerSdk/src/main/java/com/microsoft/store/partnercenter/agreements/IAgreementCollection.java
+++ b/PartnerSdk/src/main/java/com/microsoft/store/partnercenter/agreements/IAgreementCollection.java
@@ -1,0 +1,33 @@
+// -----------------------------------------------------------------------
+// <copyright file="IAgreementCollection.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation.  All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.agreements;
+
+import com.microsoft.store.partnercenter.IPartnerComponentString;
+import com.microsoft.store.partnercenter.genericoperations.IEntireEntityCollectionRetrievalOperations;
+import com.microsoft.store.partnercenter.models.ResourceCollection;
+import com.microsoft.store.partnercenter.models.agreements.Agreement;
+
+public interface IAgreementCollection
+        extends IPartnerComponentString,
+        IEntireEntityCollectionRetrievalOperations<Agreement, ResourceCollection<Agreement>>
+{
+    /***
+     * Adds accepted agreement.
+     *
+     * @param newEntity Agreement to add.
+     *
+     * @return Agreement entity.
+     */
+    Agreement create( Agreement newEntity );
+
+    /***
+     * Retrieves all agreements.
+     *
+     * @return The agreements.
+     */
+    ResourceCollection<Agreement> get();
+}

--- a/PartnerSdk/src/main/java/com/microsoft/store/partnercenter/agreements/IAgreementMetaDataCollection.java
+++ b/PartnerSdk/src/main/java/com/microsoft/store/partnercenter/agreements/IAgreementMetaDataCollection.java
@@ -1,0 +1,20 @@
+// -----------------------------------------------------------------------
+// <copyright file="IAgreementMetaDataCollection.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation.  All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.agreements;
+
+import com.microsoft.store.partnercenter.models.ResourceCollection;
+import com.microsoft.store.partnercenter.models.agreements.AgreementMetaData;
+
+public interface IAgreementMetaDataCollection
+{
+    /***
+     * Retrieves all current agreement metadata.
+     *
+     * @return The current agreement metadata.
+     */
+    ResourceCollection<AgreementMetaData> get();
+}

--- a/PartnerSdk/src/main/java/com/microsoft/store/partnercenter/customers/CustomerOperations.java
+++ b/PartnerSdk/src/main/java/com/microsoft/store/partnercenter/customers/CustomerOperations.java
@@ -13,6 +13,8 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.microsoft.store.partnercenter.BasePartnerComponentString;
 import com.microsoft.store.partnercenter.IPartner;
 import com.microsoft.store.partnercenter.PartnerService;
+import com.microsoft.store.partnercenter.agreements.AgreementCollectionOperations;
+import com.microsoft.store.partnercenter.agreements.IAgreementCollection;
 import com.microsoft.store.partnercenter.analytics.CustomerAnalyticsCollectionOperations;
 import com.microsoft.store.partnercenter.analytics.ICustomerAnalyticsCollection;
 import com.microsoft.store.partnercenter.carts.CartCollectionOperations;
@@ -75,6 +77,11 @@ public class CustomerOperations
      * The customer subscriptions operations.
      */
     private ISubscriptionCollection subscriptions;
+
+    /**
+     * The customer agreements operations.
+     */
+    private IAgreementCollection agreements;
 
     /**
      * The customer orders operations.
@@ -202,6 +209,21 @@ public class CustomerOperations
             throw new IllegalArgumentException( "customerId must be set" );
         }
         this.customerId = customerId;
+    }
+
+    /**
+     * Obtains the accepted agreements for the customer.
+     *
+     * @return The customer accepted agreements.
+     */
+    @Override
+    public IAgreementCollection getAgreements()
+    {
+        if ( this.agreements == null )
+        {
+            this.agreements = new AgreementCollectionOperations( this.getPartner(), this.customerId );
+        }
+        return this.agreements;
     }
 
     /**

--- a/PartnerSdk/src/main/java/com/microsoft/store/partnercenter/customers/ICustomer.java
+++ b/PartnerSdk/src/main/java/com/microsoft/store/partnercenter/customers/ICustomer.java
@@ -7,6 +7,7 @@
 package com.microsoft.store.partnercenter.customers;
 
 import com.microsoft.store.partnercenter.IPartnerComponentString;
+import com.microsoft.store.partnercenter.agreements.IAgreementCollection;
 import com.microsoft.store.partnercenter.analytics.ICustomerAnalyticsCollection;
 import com.microsoft.store.partnercenter.carts.ICartCollection;
 import com.microsoft.store.partnercenter.customerdirectoryroles.IDirectoryRoleCollection;
@@ -40,6 +41,13 @@ import com.microsoft.store.partnercenter.usage.ICustomerUsageSummary;
 public interface ICustomer
     extends IPartnerComponentString, IEntityGetOperations<Customer>, IEntityDeleteOperations<Customer>
 {
+    /**
+     * Gets the agreements behavior for the customer.
+     *
+     * @return The customer agreements.
+     */
+    IAgreementCollection getAgreements();
+
     /**
      * Gets the orders behavior for the customer.
      *

--- a/PartnerSdk/src/main/java/com/microsoft/store/partnercenter/models/agreements/Agreement.java
+++ b/PartnerSdk/src/main/java/com/microsoft/store/partnercenter/models/agreements/Agreement.java
@@ -1,0 +1,97 @@
+// -----------------------------------------------------------------------
+// <copyright file="Agreement.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation.  All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.models.agreements;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.microsoft.store.partnercenter.models.Contact;
+import com.microsoft.store.partnercenter.models.ResourceBase;
+import org.joda.time.DateTime;
+
+public class Agreement
+        extends ResourceBase
+{
+    /**
+     * Gets or sets the agreement identifier.
+     */
+    @JsonProperty( "userId" )
+    private String __UserId;
+
+    public String getUserId()
+    {
+        return __UserId;
+    }
+
+    public void setUserId( String value )
+    {
+        __UserId = value;
+    }
+
+    @JsonProperty( "primaryContact" )
+    private Contact __PrimaryContact;
+
+    public Contact getPrimaryContact()
+    {
+        return __PrimaryContact;
+    }
+
+    public void setPrimaryContact( Contact value )
+    {
+        __PrimaryContact = value;
+    }
+
+    @JsonProperty( "templateId" )
+    private String __TemplateId;
+
+    public String getTemplateId()
+    {
+        return __TemplateId;
+    }
+
+    public void setTemplateId( String value )
+    {
+        __TemplateId = value;
+    }
+
+    @JsonProperty( "dateAgreed" )
+    private DateTime __DateAgreed;
+
+    public DateTime getDateAgreed()
+    {
+        return __DateAgreed;
+    }
+
+    public void setDateAgreed( DateTime value )
+    {
+        __DateAgreed = value;
+    }
+
+    @JsonProperty( "type" )
+    private AgreementType __Type;
+
+    public AgreementType getType()
+    {
+        return __Type;
+    }
+
+    public void setType( AgreementType value )
+    {
+        __Type = value;
+    }
+
+    @JsonProperty( "agreementLink" )
+    private String __AgreementLink;
+
+    public String getAgreementLink()
+    {
+        return __AgreementLink;
+    }
+
+    public void setAgreementLink( String value )
+    {
+        __AgreementLink = value;
+    }
+}

--- a/PartnerSdk/src/main/java/com/microsoft/store/partnercenter/models/agreements/AgreementMetaData.java
+++ b/PartnerSdk/src/main/java/com/microsoft/store/partnercenter/models/agreements/AgreementMetaData.java
@@ -1,0 +1,67 @@
+// -----------------------------------------------------------------------
+// <copyright file="AgreementMetaData.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation.  All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.models.agreements;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class AgreementMetaData
+{
+    /**
+     * Gets or sets the agreement metadata identifier.
+     */
+    @JsonProperty( "templateId" )
+    private String __TemplateId;
+
+    public String getTemplateId()
+    {
+        return __TemplateId;
+    }
+
+    public void setTemplateId( String value )
+    {
+        __TemplateId = value;
+    }
+
+    @JsonProperty( "agreementType" )
+    private AgreementType __AgreementType;
+
+    public AgreementType getAgreementType()
+    {
+        return __AgreementType;
+    }
+
+    public void setAgreementType( AgreementType value )
+    {
+        __AgreementType = value;
+    }
+
+    @JsonProperty( "agreementLink" )
+    private String __AgreementLink;
+
+    public String getAgreementLink()
+    {
+        return __AgreementLink;
+    }
+
+    public void setAgreementLink( String value )
+    {
+        __AgreementLink = value;
+    }
+
+    @JsonProperty( "versionRank" )
+    private int __VersionRank;
+
+    public int getVersionRank()
+    {
+        return __VersionRank;
+    }
+
+    public void setVersionRank( int value )
+    {
+        __VersionRank = value;
+    }
+}

--- a/PartnerSdk/src/main/java/com/microsoft/store/partnercenter/models/agreements/AgreementType.java
+++ b/PartnerSdk/src/main/java/com/microsoft/store/partnercenter/models/agreements/AgreementType.java
@@ -1,0 +1,18 @@
+// -----------------------------------------------------------------------
+// <copyright file="AgreementType.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation.  All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.models.agreements;
+
+/**
+ * Enumeration to represent type of Agreements
+ */
+public enum AgreementType
+{
+    /***
+     * Microsoft Cloud agreement
+     */
+    MicrosoftCloudAgreement
+}

--- a/Samples/src/main/java/com/microsoft/store/partnercenter/samples/Program.java
+++ b/Samples/src/main/java/com/microsoft/store/partnercenter/samples/Program.java
@@ -10,6 +10,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.microsoft.store.partnercenter.models.customers.CustomerSearchField;
+import com.microsoft.store.partnercenter.samples.agreements.CreateAgreement;
+import com.microsoft.store.partnercenter.samples.agreements.GetAgreementMetadata;
+import com.microsoft.store.partnercenter.samples.agreements.GetAgreements;
 import com.microsoft.store.partnercenter.samples.analytics.GetPartnerLicensesDeploymentAnalytics;
 import com.microsoft.store.partnercenter.samples.analytics.GetPartnerLicensesUsageAnalytics;
 import com.microsoft.store.partnercenter.samples.analytics.GetCustomerLicensesDeploymentAnalytics;
@@ -161,6 +164,7 @@ public class Program
         mainScenarios.add( Program.getOfferScenarios(context));
         mainScenarios.add( Program.getProductScenarios(context));
         mainScenarios.add( Program.getCustomerProductsScenarios(context));
+        mainScenarios.add( Program.getAgreementScenarios(context));
         mainScenarios.add( Program.getOrderScenarios(context));
         mainScenarios.add( Program.getSubscriptionScenarios(context));
         mainScenarios.add( Program.getRatedUsageScenarios(context));
@@ -238,6 +242,21 @@ public class Program
         offerScenarios.add( new GetCustomerOfferCategories( context ) );
 
         return new AggregatePartnerScenario( "Offer samples", offerScenarios, context );
+    }
+
+    /**
+     * Gets the agreement scenarios.
+     *
+     * @param context A scenario context.
+     * @return The agreement scenarios.
+     */
+    private static IPartnerScenario getAgreementScenarios( IScenarioContext context )
+    {
+        List<IPartnerScenario> agreementScenarios = new ArrayList<IPartnerScenario>();
+        agreementScenarios.add( new GetAgreementMetadata( context ) );
+        agreementScenarios.add( new CreateAgreement( context ) );
+        agreementScenarios.add( new GetAgreements( context ) );
+        return new AggregatePartnerScenario( "Agreement samples", agreementScenarios, context );
     }
 
     /**

--- a/Samples/src/main/java/com/microsoft/store/partnercenter/samples/agreements/CreateAgreement.java
+++ b/Samples/src/main/java/com/microsoft/store/partnercenter/samples/agreements/CreateAgreement.java
@@ -1,0 +1,87 @@
+// -----------------------------------------------------------------------
+// <copyright file="CreateAgreement.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation.  All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.samples.agreements;
+
+import com.microsoft.store.partnercenter.IPartner;
+import com.microsoft.store.partnercenter.models.Contact;
+import com.microsoft.store.partnercenter.models.ResourceCollection;
+import com.microsoft.store.partnercenter.models.agreements.Agreement;
+import com.microsoft.store.partnercenter.models.agreements.AgreementMetaData;
+import com.microsoft.store.partnercenter.models.agreements.AgreementType;
+import com.microsoft.store.partnercenter.samples.BasePartnerScenario;
+import com.microsoft.store.partnercenter.samples.IScenarioContext;
+import org.joda.time.DateTime;
+
+/**
+ * A scenario that confirm customer acceptance of Microsoft Cloud agreement.
+ */
+public class CreateAgreement
+        extends BasePartnerScenario
+{
+    /**
+     * Initializes a new instance of the {@link #CreateAgreement} class.
+     *
+     * @param context The scenario context.
+     */
+    public CreateAgreement( IScenarioContext context )
+    {
+        super( "Confirm customer acceptance of Microsoft Cloud agreement", context );
+    }
+
+    /**
+     * Executes the scenario.
+     */
+    @Override
+    protected void runScenario()
+    {
+        IPartner partnerOperations = this.getContext().getUserPartnerOperations();
+        String customerId = this.obtainCustomerId( "Enter the ID of the customer who confirms acceptance of Microsoft Cloud agreement" );
+        String userId = this.obtainCustomerUserId( "Enter the ID of the logged in user in the partner tenant who is providing confirmation on behalf of the partner organization" );
+
+        this.getContext().getConsoleHelper().startProgress( "Retrieving agreement metadata for Microsoft Cloud Agreement" );
+        ResourceCollection<AgreementMetaData> metaDataCollection =
+                partnerOperations.getAgreements().get();
+        this.getContext().getConsoleHelper().stopProgress();
+
+        AgreementMetaData metaData = null;
+
+        for ( AgreementMetaData item : metaDataCollection.getItems() )
+        {
+            if ( item.getAgreementType().equals( AgreementType.MicrosoftCloudAgreement ) )
+            {
+                metaData = item;
+                break;
+            }
+        }
+
+        if ( metaData == null )
+        {
+            this.getContext().getConsoleHelper().error( "No agreement metadata for Microsoft Cloud Agreement found" );
+        }
+        else
+        {
+            Contact primaryContact = new Contact();
+            primaryContact.setFirstName( "Tania" );
+            primaryContact.setLastName( "Carr" );
+            primaryContact.setEmail( "SomeEmail@Outlook.com" );
+            primaryContact.setPhoneNumber( "1234567890" );
+
+            Agreement agreementToCreate = new Agreement();
+            agreementToCreate.setTemplateId( metaData.getTemplateId() );
+            agreementToCreate.setType( metaData.getAgreementType() );
+            agreementToCreate.setUserId( userId );
+            agreementToCreate.setDateAgreed( DateTime.now() );
+            agreementToCreate.setPrimaryContact( primaryContact );
+
+            this.getContext().getConsoleHelper().startProgress( "Confirmation customer acceptance of Microsoft Cloud agreement" );
+            Agreement agreement =
+                    partnerOperations.getCustomers().byId( customerId ).getAgreements().create( agreementToCreate );
+            this.getContext().getConsoleHelper().stopProgress();
+            this.getContext().getConsoleHelper().writeObject( agreement, "Accepted agreement" );
+        }
+    }
+}

--- a/Samples/src/main/java/com/microsoft/store/partnercenter/samples/agreements/GetAgreementMetadata.java
+++ b/Samples/src/main/java/com/microsoft/store/partnercenter/samples/agreements/GetAgreementMetadata.java
@@ -1,0 +1,51 @@
+// -----------------------------------------------------------------------
+// <copyright file="GetAgreementMetadata.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation.  All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.samples.agreements;
+
+import com.microsoft.store.partnercenter.IPartner;
+import com.microsoft.store.partnercenter.models.ResourceCollection;
+import com.microsoft.store.partnercenter.models.agreements.AgreementMetaData;
+import com.microsoft.store.partnercenter.samples.BasePartnerScenario;
+import com.microsoft.store.partnercenter.samples.IScenarioContext;
+
+/**
+ * A scenario that retrieves agreement metadata.
+ */
+public class GetAgreementMetadata
+        extends BasePartnerScenario
+{
+    /**
+     * Initializes a new instance of the {@link #GetAgreementMetadata} class.
+     *
+     * @param context The scenario context.
+     */
+    public GetAgreementMetadata( IScenarioContext context )
+    {
+        super( "Get agreement metadata", context );
+    }
+
+    /**
+     * Executes the scenario.
+     */
+    @Override
+    protected void runScenario()
+    {
+        IPartner partnerOperations = this.getContext().getUserPartnerOperations();
+        this.getContext().getConsoleHelper().startProgress( "Retrieving agreement metadata" );
+        ResourceCollection<AgreementMetaData> agreementMetaData =
+                partnerOperations.getAgreements().get();
+        this.getContext().getConsoleHelper().stopProgress();
+        if (agreementMetaData.getItems().iterator().hasNext())
+        {
+            this.getContext().getConsoleHelper().writeObject( agreementMetaData, "Agreement metadata" );
+        }
+        else
+        {
+            this.getContext().getConsoleHelper().warning( "No agreement metadata found" );
+        }
+    }
+}

--- a/Samples/src/main/java/com/microsoft/store/partnercenter/samples/agreements/GetAgreements.java
+++ b/Samples/src/main/java/com/microsoft/store/partnercenter/samples/agreements/GetAgreements.java
@@ -1,0 +1,45 @@
+// -----------------------------------------------------------------------
+// <copyright file="GetAgreements.java" company="Microsoft">
+//      Copyright (c) Microsoft Corporation.  All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+package com.microsoft.store.partnercenter.samples.agreements;
+
+import com.microsoft.store.partnercenter.IPartner;
+import com.microsoft.store.partnercenter.models.ResourceCollection;
+import com.microsoft.store.partnercenter.models.agreements.Agreement;
+import com.microsoft.store.partnercenter.samples.BasePartnerScenario;
+import com.microsoft.store.partnercenter.samples.IScenarioContext;
+
+/**
+ * A scenario that retrieves a confirmation of customer acceptance of Microsoft Cloud agreement.
+ */
+public class GetAgreements
+        extends BasePartnerScenario
+{
+    /**
+     * Initializes a new instance of the {@link #GetAgreements} class.
+     *
+     * @param context The scenario context.
+     */
+    public GetAgreements( IScenarioContext context )
+    {
+        super( "Get confirmation of customer acceptance of Microsoft Cloud agreement", context );
+    }
+
+    /**
+     * Executes the scenario.
+     */
+    @Override
+    protected void runScenario()
+    {
+        IPartner partnerOperations = this.getContext().getUserPartnerOperations();
+        String customerId = this.obtainCustomerId( "Enter the ID of the customer whom to retrieve their confirmation of acceptance of Microsoft Cloud agreement" );
+        this.getContext().getConsoleHelper().startProgress( "Retrieving a confirmation of customer acceptance of Microsoft Cloud agreement" );
+        ResourceCollection<Agreement> agreements =
+                partnerOperations.getCustomers().byId( customerId ).getAgreements().get();
+        this.getContext().getConsoleHelper().stopProgress();
+        this.getContext().getConsoleHelper().writeObject( agreements, "Accepted agreements" );
+    }
+}


### PR DESCRIPTION
Implement API methods for acceptance agreement:
* Get agreement metadata for Microsoft Cloud Agreement
* Get confirmation of customer acceptance of Microsoft Cloud agreement
* Confirm customer acceptance of Microsoft Cloud agreement

# Description

Confirm customer acceptance of the Microsoft Cloud Agreement since November 7, 2018 is mandatory:
* https://docs.microsoft.com/en-us/partner-center/confirm-consent

This pull request implements three necessary methods:
* https://docs.microsoft.com/en-us/partner-center/develop/get-agreement-metadata
* https://docs.microsoft.com/en-us/partner-center/develop/get-confirmation-of-customer-consent
* https://docs.microsoft.com/en-us/partner-center/develop/confirm-customer-consent

